### PR TITLE
Fix issue #15: Restore original functionality for the tourettes command.

### DIFF
--- a/src/services/__tests__/tourettes.test.js
+++ b/src/services/__tests__/tourettes.test.js
@@ -19,20 +19,20 @@ describe('tourettes', () => {
     describe('when input text is empty', () => {
       const inputText = '';
 
-      it('replies with an item from the profanities list', () => {
+      it('replies with at least three items from the profanities list', () => {
         const reply = sayTourettes(inputText);
         expect(reply).toNotBe(undefined);
-        expect(reply.length).toBeGreaterThan(1);
+        expect(reply.split(' ').length).toBeGreaterThan(3);
       });
     });
 
     describe('when inputText is undefined', () => {
       const inputText = undefined;
 
-      it('replies with an item from the profanities list', () => {
+      it('replies with at least three items from the profanities list', () => {
         const reply = sayTourettes(inputText);
         expect(reply).toNotBe(undefined);
-        expect(reply.length).toBeGreaterThan(1);
+        expect(reply.split(' ').length).toBeGreaterThan(3);
       });
     });
 

--- a/src/services/tourettes.js
+++ b/src/services/tourettes.js
@@ -52,7 +52,21 @@ function hasNoProfanity(inputText, reply) {
   return inputTextWordCount === replyWordCount;
 }
 
-export function sayTourettes(inputText = getRandomProfanity()) {
+function getProfanities(amount) {
+  const profanityReply = [];
+  let count = 0;
+  while (count < amount) {
+    profanityReply.push(getRandomProfanity());
+    count += 1;
+  }
+  return profanityReply.join(' ');
+}
+
+export function sayTourettes(inputText = '') {
+  if (inputText === '') {
+    return getProfanities(getRandomNumber(3, 10));
+  }
+
   const reply = spewTourettes(inputText.split(' '));
   if (hasNoProfanity(inputText, reply)) {
     return `${reply} ${getRandomProfanity()}`;


### PR DESCRIPTION
I.e. no input text generates between three and ten profanities.
